### PR TITLE
Fixing & symbols at tracking query string to make it HTML5 valid

### DIFF
--- a/promote-mdn.php
+++ b/promote-mdn.php
@@ -31,7 +31,7 @@ class PromoteMDN {
         'maxsingleurl' => '1',
         'hide_notices' => array( '1.3' => 1, '1.4' => 1, '1.5' => 1 ),
     );
-    public $tracking_querystring = '?utm_source=wordpress%%20blog&utm_medium=content%%20link&utm_campaign=promote%%20mdn';
+    public $tracking_querystring = '?utm_source=wordpress%%20blog&amp;utm_medium=content%%20link&amp;utm_campaign=promote%%20mdn';
 
     function __construct( $options = null )
     {


### PR DESCRIPTION
Currently, links generated make your website not valid with the W3C Html5 validator, which is something bad for a Mozilla plugin. So I've fixed link to make it HTML5 valid.